### PR TITLE
fix semantic-release notes generation

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           semantic-version: "latest"
+          extra-plugins: |
+            @semantic-release/changelog@^6
+            @semantic-release/git@^10
+            conventional-changelog-conventionalcommits@9.3.1
 
       - name: Run SBOM Generation (CycloneDX)
         if: steps.release.outputs.new-release-published == 'true'
@@ -55,7 +59,7 @@ jobs:
         if: steps.release.outputs.new-release-published == 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: v${{ steps.release.outputs.new-release-version }}
+          tag_name: ${{ steps.release.outputs.new-release-git-tag }}
           files: |
             sbom.cdx.json
             sbom.spdx.json


### PR DESCRIPTION
## Summary

Fixes the semantic-release workflow that produced header-only changelog and GitHub Release entries for valid `fix(...)` commits.

## Root cause

The shared semantic-release action installs `conventional-changelog-conventionalcommits@^10`, while `@semantic-release/release-notes-generator@14.x` still renders through `conventional-changelog-writer@^8`. The v10 preset exposes function-based writer templates that are incompatible with writer v8's Handlebars template interface, so semantic-release can correctly determine a patch release while rendering no commit sections.

## Changes

- Override `extra-plugins` in this repository and pin `conventional-changelog-conventionalcommits@9.3.1`, matching the release-notes-generator compatibility line.
- Preserve `@semantic-release/changelog` and `@semantic-release/git` in the override because `extra-plugins` replaces the action default.
- Publish SBOM assets using `steps.release.outputs.new-release-git-tag` instead of reconstructing `v${version}`, keeping artifact publication aligned with `.releaserc.json`'s tag format.

## Impact

Future `fix`, `feat`, and other visible Conventional Commits should produce populated release notes and changelog sections instead of header-only entries. SBOM publication will target the exact tag created by semantic-release.

## Validation

- Branch is one commit ahead of `main` and modifies only `.github/workflows/semantic-release.yml`.
- The workflow override retains all previously installed extra plugins while changing only the Conventional Commits preset version.
- The tag expression now consumes the action's canonical `new-release-git-tag` output directly.
