### PR TITLE
chore: refine Renovate Go workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,9 @@ jobs:
           persist-credentials: false
 
       - name: Run Renovate
-        uses: sentenz/actions/renovate@62c4352acdd45163bd10ae248b71c6ad6a99e3c3 # 1.4.1
+        uses: sentenz/actions/renovate@99935197a6935a691cb151a3e469f1a969bf7714 # 1.4.2
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           autodiscover: "false"
+        env:
+          RENOVATE_CONFIG_VALIDATION_ERROR: "true"

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -37,18 +37,17 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update versioned Docker image references in Makefiles and KinD cluster configuration.",
+      "description": "Update versioned Docker image references in Makefiles.",
       "managerFilePatterns": [
         "**/[Mm]akefile",
         "**/GNUMakefile",
-        "**/*.mk",
-        "**/kind-cluster.{yml,yaml}"
+        "**/*.mk"
       ],
       "matchStringsStrategy": "any",
       "matchStrings": [
         "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
-      "autoReplaceStringTemplate": "{{{prefix}}}{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{else}}{{#if currentDigest}}@{{{currentDigest}}}{{/if}}{{/if}}",
+      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{else}}{{#if currentDigest}}@{{{currentDigest}}}{{/if}}{{/if}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
@@ -57,7 +56,8 @@
     {
       "description": "Group major updates.",
       "matchManagers": [
-        "!gomod"
+        "!gomod",
+        "!github-actions"
       ],
       "matchDatasources": [
         "!docker"
@@ -72,7 +72,8 @@
     {
       "description": "Group minor updates.",
       "matchManagers": [
-        "!gomod"
+        "!gomod",
+        "!github-actions"
       ],
       "matchDatasources": [
         "!docker"
@@ -87,7 +88,8 @@
     {
       "description": "Group patch updates.",
       "matchManagers": [
-        "!gomod"
+        "!gomod",
+        "!github-actions"
       ],
       "matchDatasources": [
         "!docker"
@@ -100,18 +102,36 @@
       "automerge": false
     },
     {
-      "description": "Group Go dependency updates from go.mod and go.sum.",
+      "description": "Only propose Go module updates compatible with the repository Go version.",
       "matchManagers": [
         "gomod"
       ],
-      "matchFileNames": [
-        "go.mod",
-        "go.sum"
+      "constraintsFiltering": "strict"
+    },
+    {
+      "description": "Group major Go module dependency updates separately.",
+      "matchManagers": [
+        "gomod"
       ],
       "matchUpdateTypes": [
-        "major",
+        "major"
+      ],
+      "groupName": "go major dependencies",
+      "groupSlug": "go-major-dependencies",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "deps",
+      "automerge": false
+    },
+    {
+      "description": "Group non-major Go module dependency updates.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest"
       ],
       "groupName": "go dependencies",
       "groupSlug": "go-dependencies",
@@ -183,6 +203,23 @@
       "groupName": "makefile container images",
       "groupSlug": "makefile-container-images",
       "automerge": true
+    },
+    {
+      "description": "Group non-container GitHub Actions dependency updates.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "action",
+        "uses-with",
+        "github-runner"
+      ],
+      "groupName": "github actions dependencies",
+      "groupSlug": "github-actions-dependencies",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "deps",
+      "automerge": false
     },
     {
       "description": "Pin Docker images used by GitHub Actions to immutable digests.",


### PR DESCRIPTION
## Summary

Refine the repository's Renovate configuration using the Terraform template as a baseline while adapting grouping and compatibility behavior to Go.

## Changes

- enforce strict Go module compatibility against the repository's `go` directive
- separate major Go module updates from minor, patch, and pseudo-version digest updates
- group Go pseudo-version digest updates with normal Go dependencies
- exclude `github-actions` from the generic semantic-version groups and add a dedicated non-container GitHub Actions dependency group
- preserve the existing Docker-backed GitHub Actions image policy
- remove the stale Kind file matcher from the custom Docker manager and remove the undefined `prefix` replacement variable
- update `sentenz/actions/renovate` from 1.4.1 to 1.4.2
- make Renovate configuration validation errors fail the workflow

## Rationale

The repository currently declares Go 1.25.0. Renovate recommends strict constraint filtering for Go projects when dependency compatibility should respect the repository's Go version.

Go major module upgrades can require module-path and source import changes, so they are isolated into a separate review group without enabling automated import-path rewrites or automerge. Minor, patch, and pseudo-version digest updates remain grouped as normal Go dependencies.

Recent Renovate runs also exposed two grouping gaps: Go pseudo-version updates were emitted as individual digest PRs, while ordinary GitHub Actions references with depType `action` fell into the generic patch group. The revised package rules cover both cases explicitly.

The repository has no Kind cluster configuration, so the Kind matcher was dead configuration. The custom manager regex also did not define a `prefix` capture, so the replacement template no longer references it.

## Validation

- branch is based on current `main` and is 0 commits behind
- only `renovate.jsonc` and `.github/workflows/renovate.yml` are changed
- resulting Renovate configuration parses as JSON
- verified the Go compatibility rule and Go manager behavior against current Renovate documentation
- verified GitHub Actions depTypes against the current Renovate GitHub Actions manager documentation
- no local Renovate validator binary is available; the workflow now uses `RENOVATE_CONFIG_VALIDATION_ERROR=true` so configuration errors fail CI
- existing repository schedule, concurrency, checkout hardening, Docker grouping, and automerge policy are preserved
