### PR TITLE
fix(renovate): tidy Go modules before vendoring

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -106,7 +106,10 @@
       "matchManagers": [
         "gomod"
       ],
-      "constraintsFiltering": "strict"
+      "constraintsFiltering": "strict",
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
     },
     {
       "description": "Group major Go module dependency updates separately.",


### PR DESCRIPTION
## Summary

Enable Renovate's `gomodTidy` post-update option for Go modules.

Renovate automatically runs `go mod vendor` when `vendor/modules.txt` is present. PR #143 currently fails because updated direct module versions left `go.sum`/the selected transitive graph incomplete, so vendoring could not regenerate. Running `go mod tidy` first lets Renovate reconcile `go.mod` and `go.sum` before its automatic vendor step.

## Validation

- Configuration remains valid JSON/JSONC.
- `gomodTidy` is a supported Renovate `postUpdateOptions` value for the `gomod` manager.

Follow-up: regenerate/rebase PR #143 after this lands.